### PR TITLE
Write guide for commit style conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Guides for getting things done, programming well, and programming in style.
 
 * [Code Review](/code-review#code-review)
 * [Style](/style)
+  * [Commit Message](/style/commit-message#commit-message-style-guide)
   * [Objective-C](/style/objective-c#objective-c-style-guide)
-  * [Swift](/style/objective-c#objective-c-style-guide)
+  * [Swift](/style/swift#swift-style-guide)
   * [Ruby](https://github.com/bbatsov/ruby-style-guide#prelude)
   * [Rails](https://github.com/bbatsov/rails-style-guide#prelude)
 

--- a/style/commit-message/README.md
+++ b/style/commit-message/README.md
@@ -1,0 +1,24 @@
+# Commit Message Style Guide
+
+Conventions for commit messages:
+
+1. The first line should summarize what the commit does.
+2. The first line of the commit message should not be larger than 50 
+characters.
+3. Use present tense in imperative, present tense for the first line.
+4. If one line is not enough to describe what the commit does, then:
+  1. The first line must be followed by a blank new line.
+  2. A brief description explaining the change, between 2-4 lines 
+long, should follow the new line.
+  3. If needed, you can opt to add another blank line, and below, 
+a bulleted list of individual changes prefixed with a star (\*).
+  4. None of these additional lines should exceed 70 characters.
+
+**Example:**
+
+```
+Write guide for commit style conventions
+
+In order to have the same style and to have better commit messages 
+we created a guide that the team members must follow to write them.
+```


### PR DESCRIPTION
In order to have the same style and to have better commit messages
we created a guide that the team members must follow to write them.